### PR TITLE
Add missing default value functionality to config

### DIFF
--- a/App/resources/scripts/artic/models/AppModel.js
+++ b/App/resources/scripts/artic/models/AppModel.js
@@ -367,7 +367,7 @@ function AppModel() {
 
 	function isInPriorityGallery(artwork) {
 
-		var ids	= _config.has("priorityGalleryIds") ? _config.val("priorityGalleryIds") : [ ];
+		var ids	= _config.val("priorityGalleryIds", [ ]);
 
 		for (var i = 0; i < ids.length; i++) {
 			if (artwork.galleryId == ids[i]) {

--- a/App/resources/scripts/artic/models/ConfigModel.js
+++ b/App/resources/scripts/artic/models/ConfigModel.js
@@ -36,9 +36,17 @@ function ConfigModel() {
 
 	}
 
-	this.val = function(field) {
+	this.val = function(field, defaultVal) {
 
+		if (bwco.utils.defined(defaultVal)) {
+			if (this.has(field)) {
+				return _data[field];
+			} else {
+				return defaultVal;
+			}
+		} else {
 		return _data[field];
+		}
 
 	}
 


### PR DESCRIPTION
The val method of the ConfigModel is meant to have this default value
second argument (in case the config field doesn’t exist), and somehow
never made it in (despite being expected in a number of places in the
code).