### PR TITLE
Fix alignment of home companion help item in print step

### DIFF
--- a/App/resources/css/style.css
+++ b/App/resources/css/style.css
@@ -3481,7 +3481,7 @@ body.home-companion #wrap-sections section#print div.name-form div.name-field di
 body.home-companion #wrap-sections section#print div.name-form div.name-field div.help-item > div.unnamed,
 body.home-companion #wrap-sections section#print div.name-form div.name-field div.help-item > div.named {
   position: absolute;
-  right: -90px;
+  right: 67px;
   bottom: 107px;
 }
 body.home-companion #wrap-sections section#print div.name-form div.name-field div.help-item > div.unnamed div.stem,

--- a/App/resources/less/home-companion.less
+++ b/App/resources/less/home-companion.less
@@ -1023,7 +1023,7 @@ body.home-companion {
 							}
 						}
 						&.unnamed {
-							right: -90px;
+							right: 67px;
 						}
 						&.named {
 							right: 70px;


### PR DESCRIPTION
Help item for Home Companion about printing was pointed (incorrectly) at the "Start Over" button. It's now pointed at the "Create Guide" button