### PR TITLE
Fix alignment of help item in print step

### DIFF
--- a/App/resources/css/style.css
+++ b/App/resources/css/style.css
@@ -2545,10 +2545,14 @@ body.help-on #wrap-sections section#build div.obj.help-selected .help-item {
 #wrap-sections section#print div.name-form div.name-field div.help-item > div {
   display: none;
 }
-#wrap-sections section#print div.name-form div.name-field div.help-item > div.unnamed,
+#wrap-sections section#print div.name-form div.name-field div.help-item > div.unnamed {
+  position: absolute;
+  right: -95px;
+  bottom: -142px;
+}
 #wrap-sections section#print div.name-form div.name-field div.help-item > div.named {
   position: absolute;
-  right: -110px;
+  right: 60px;
   bottom: -142px;
 }
 #wrap-sections section#print div.name-form div.name-field div.help-item > div.unnamed div.stem,

--- a/App/resources/less/section-print.less
+++ b/App/resources/less/section-print.less
@@ -367,7 +367,7 @@
 						}
 					}
 					&.unnamed {
-						right: -110px;
+						right: -95px;
 					}
 					&.named {
 						right: 60px;


### PR DESCRIPTION
[This pull request](https://github.com/art-institute-of-chicago/journeymaker-client/pull/10) addressed the alignment of this help item in the home companion, but was not fixed in the kiosk version.

This should fix the alignment for the kiosk version.